### PR TITLE
Fix input with empty host

### DIFF
--- a/src/config/schema.ts
+++ b/src/config/schema.ts
@@ -6,7 +6,7 @@ export const ConfigSchema = z
     host: z.string(),
     port: z.number().int().positive(),
     endpoint: z.string().startsWith('/'),
-    serverUrl: z.string().url().optional(),
+    serverUrl: z.string().optional(),
   })
   .transform(({ host, port, endpoint }) => ({
     host,


### PR DESCRIPTION
When host was empty, Zod didn't allow any updates, making it impossible to update the host.
