### PR TITLE
Add config detection and reset to default

### DIFF
--- a/src/config/schema.test.ts
+++ b/src/config/schema.test.ts
@@ -4,7 +4,7 @@ describe('ConfigSchema', () => {
   it('should be valid config', () => {
     const validConfig = {
       host: 'localhost',
-      port: 8448,
+      port: '8448',
       endpoint: '/api/v1/ws',
     }
     expect(ConfigSchema.parse(validConfig).serverUrl).toEqual('ws://localhost:8448/api/v1/ws')
@@ -13,29 +13,52 @@ describe('ConfigSchema', () => {
   it('should parse serverUrl', () => {
     const validConfig = {
       host: 'localhost',
-      port: 8448,
+      port: '8448',
       endpoint: '/api/v1/ws',
     }
     expect(ConfigSchema.parse(validConfig).serverUrl).toEqual('ws://localhost:8448/api/v1/ws')
   })
 
-  it('should throw with invalid port', () => {
-    const invalidConfig = {
-      host: 'localhost',
-      port: -1,
-      endpoint: '/api/v1/ws',
-      serverUrl: 'ws://localhost:8448/api/v1/ws',
-    }
-    expect(() => ConfigSchema.parse(invalidConfig)).toThrow()
+  describe(`Port`, () => {
+    it('should pass with empty port', () => {
+      const invalidConfig = {
+        host: 'localhost',
+        endpoint: '/api/v1/ws',
+        serverUrl: 'ws://localhost:8448/api/v1/ws',
+      }
+      expect(ConfigSchema.parse(invalidConfig).port).toEqual(undefined)
+    })
+
+    it('should throw with invalid port that is to low', () => {
+      const invalidConfig = {
+        host: 'localhost',
+        port: '-1',
+        endpoint: '/api/v1/ws',
+        serverUrl: 'ws://localhost:8448/api/v1/ws',
+      }
+      expect(() => ConfigSchema.parse(invalidConfig)).toThrow()
+    })
+
+    it('should throw with invalid port that is to high', () => {
+      const invalidConfig = {
+        host: 'localhost',
+        port: '70000',
+        endpoint: '/api/v1/ws',
+        serverUrl: 'ws://localhost:8448/api/v1/ws',
+      }
+      expect(() => ConfigSchema.parse(invalidConfig)).toThrow()
+    })
   })
 
-  it('should throw with invalid endpoint', () => {
-    const invalidConfig = {
-      host: 'localhost',
-      port: 8448,
-      endpoint: 'api/v1/ws',
-      serverUrl: 'ws://localhost:8448/api/v1/ws',
-    }
-    expect(() => ConfigSchema.parse(invalidConfig)).toThrow()
+  describe(`Endpoint`, () => {
+    it('should throw with invalid endpoint', () => {
+      const invalidConfig = {
+        host: 'localhost',
+        port: '8448',
+        endpoint: 'api/v1/ws',
+        serverUrl: 'ws://localhost:8448/api/v1/ws',
+      }
+      expect(() => ConfigSchema.parse(invalidConfig)).toThrow()
+    })
   })
 })

--- a/src/config/schema.test.ts
+++ b/src/config/schema.test.ts
@@ -3,7 +3,7 @@ import { ConfigSchema } from './schema'
 describe('ConfigSchema', () => {
   it('should be valid config', () => {
     const validConfig = {
-      host: 'localhost',
+      hostname: 'localhost',
       port: '8448',
       endpoint: '/api/v1/ws',
     }
@@ -12,17 +12,28 @@ describe('ConfigSchema', () => {
 
   it('should parse serverUrl', () => {
     const validConfig = {
-      host: 'localhost',
+      hostname: 'localhost',
       port: '8448',
       endpoint: '/api/v1/ws',
     }
     expect(ConfigSchema.parse(validConfig).serverUrl).toEqual('ws://localhost:8448/api/v1/ws')
   })
 
+  describe(`hostname`, () => {
+    it('should throw with invalid endpoint', () => {
+      const invalidConfig = {
+        hostname: 'localhost',
+        port: '8448',
+        endpoint: 'api/v1/ws',
+        serverUrl: 'ws://localhost:8448/api/v1/ws',
+      }
+      expect(() => ConfigSchema.parse(invalidConfig)).toThrow()
+    })
+  })
   describe(`Port`, () => {
     it('should pass with empty port', () => {
       const invalidConfig = {
-        host: 'localhost',
+        hostname: 'localhost',
         endpoint: '/api/v1/ws',
         serverUrl: 'ws://localhost:8448/api/v1/ws',
       }
@@ -31,7 +42,7 @@ describe('ConfigSchema', () => {
 
     it('should throw with invalid port that is to low', () => {
       const invalidConfig = {
-        host: 'localhost',
+        hostname: 'localhost',
         port: '-1',
         endpoint: '/api/v1/ws',
         serverUrl: 'ws://localhost:8448/api/v1/ws',
@@ -41,7 +52,7 @@ describe('ConfigSchema', () => {
 
     it('should throw with invalid port that is to high', () => {
       const invalidConfig = {
-        host: 'localhost',
+        hostname: 'localhost',
         port: '70000',
         endpoint: '/api/v1/ws',
         serverUrl: 'ws://localhost:8448/api/v1/ws',
@@ -53,7 +64,7 @@ describe('ConfigSchema', () => {
   describe(`Endpoint`, () => {
     it('should throw with invalid endpoint', () => {
       const invalidConfig = {
-        host: 'localhost',
+        hostname: 'localhost',
         port: '8448',
         endpoint: 'api/v1/ws',
         serverUrl: 'ws://localhost:8448/api/v1/ws',

--- a/src/config/schema.ts
+++ b/src/config/schema.ts
@@ -1,11 +1,10 @@
-import { atom } from 'jotai'
 import { z } from 'zod'
 
 // @TODO (undg) 2024-09-15: I need  two schemas. One for throwing errors, second for UI errors.
 
 export const ConfigSchema = z
   .object({
-    host: z.string().describe('Server host address'),
+    hostname: z.string().describe('Server host address').optional(),
     port: z
       .string()
       .regex(/^\d+$/, { message: 'Port must be a number' })
@@ -21,22 +20,15 @@ export const ConfigSchema = z
     endpoint: z.string().startsWith('/').describe('API endpoint path starting with /'),
     serverUrl: z.string().optional().describe('Full server URL. Do not edit directly.'),
   })
-  .transform(({ host, port, endpoint }) => ({
+  .transform(({ hostname, port, endpoint }) => ({
     /** Host address for the server */
-    host,
+    hostname,
     /** Port number for the server */
     port,
     /** API endpoint path */
     endpoint,
     /** Full server URL. Automatically generated. Do not edit directly. */
-    serverUrl: `ws://${host}:${port}${endpoint}`,
+    serverUrl: `ws://${hostname}:${port}${endpoint}`,
   }))
 
 export type Config = z.infer<typeof ConfigSchema>
-
-export const ConfigAtom = atom<Config>({
-  host: 'localhost',
-  port: '8448',
-  endpoint: '/api/v1/ws',
-  serverUrl: 'ws://localhost:8448/api/v1/ws',
-})

--- a/src/config/schema.ts
+++ b/src/config/schema.ts
@@ -1,17 +1,34 @@
 import { atom } from 'jotai'
 import { z } from 'zod'
 
+// @TODO (undg) 2024-09-15: I need  two schemas. One for throwing errors, second for UI errors.
+
 export const ConfigSchema = z
   .object({
-    host: z.string(),
-    port: z.number().int().positive(),
-    endpoint: z.string().startsWith('/'),
-    serverUrl: z.string().optional(),
+    host: z.string().describe('Server host address'),
+    port: z
+      .string()
+      .regex(/^\d+$/, { message: 'Port must be a number' })
+      .refine(
+        val => {
+          const num = parseInt(val, 10)
+          return num >= 1 && num <= 65535
+        },
+        { message: 'Port must be between 1 and 65535' },
+      )
+      .optional()
+      .describe('Valid port between 1 and 65535'),
+    endpoint: z.string().startsWith('/').describe('API endpoint path starting with /'),
+    serverUrl: z.string().optional().describe('Full server URL. Do not edit directly.'),
   })
   .transform(({ host, port, endpoint }) => ({
+    /** Host address for the server */
     host,
+    /** Port number for the server */
     port,
+    /** API endpoint path */
     endpoint,
+    /** Full server URL. Automatically generated. Do not edit directly. */
     serverUrl: `ws://${host}:${port}${endpoint}`,
   }))
 
@@ -19,7 +36,7 @@ export type Config = z.infer<typeof ConfigSchema>
 
 export const ConfigAtom = atom<Config>({
   host: 'localhost',
-  port: 8448,
+  port: '8448',
   endpoint: '/api/v1/ws',
   serverUrl: 'ws://localhost:8448/api/v1/ws',
 })

--- a/src/config/use-config.test.tsx
+++ b/src/config/use-config.test.tsx
@@ -6,7 +6,7 @@ describe('useConfig', () => {
     const { result } = renderHook(() => useConfig())
     const [defaultConfig] = result.current
     expect(defaultConfig).toEqual({
-      host: 'localhost',
+      hostname: 'localhost',
       port: '8448',
       endpoint: '/api/v1/ws',
       serverUrl: 'ws://localhost:8448/api/v1/ws',
@@ -26,7 +26,7 @@ describe('useConfig', () => {
     const [updatedConfig] = result.current
 
     expect(updatedConfig).to.eql({
-      host: 'localhost',
+      hostname: 'localhost',
       port: '9000',
       endpoint: '/api/v1/ws',
       serverUrl: 'ws://localhost:9000/api/v1/ws',

--- a/src/config/use-config.test.tsx
+++ b/src/config/use-config.test.tsx
@@ -7,7 +7,7 @@ describe('useConfig', () => {
     const [defaultConfig] = result.current
     expect(defaultConfig).toEqual({
       host: 'localhost',
-      port: 8448,
+      port: '8448',
       endpoint: '/api/v1/ws',
       serverUrl: 'ws://localhost:8448/api/v1/ws',
     })
@@ -18,7 +18,7 @@ describe('useConfig', () => {
 
     act(() => {
       const [, updateConfig] = result.current
-      updateConfig({ port: 9000 })
+      updateConfig({ port: '9000' })
     })
 
     rerender()
@@ -27,7 +27,7 @@ describe('useConfig', () => {
 
     expect(updatedConfig).to.eql({
       host: 'localhost',
-      port: 9000,
+      port: '9000',
       endpoint: '/api/v1/ws',
       serverUrl: 'ws://localhost:9000/api/v1/ws',
     })

--- a/src/config/use-config.tsx
+++ b/src/config/use-config.tsx
@@ -6,7 +6,7 @@ import { useAtomDevtools } from 'jotai-devtools'
 
 const defaultConfig: Config = {
   host: 'localhost',
-  port: 8448,
+  port: '8448',
   endpoint: '/api/v1/ws',
   serverUrl: 'ws://localhost:8448/api/v1/ws',
 }

--- a/src/config/use-config.tsx
+++ b/src/config/use-config.tsx
@@ -4,12 +4,12 @@ import type { Config } from './schema'
 import { ConfigSchema } from './schema'
 import { useAtomDevtools } from 'jotai-devtools'
 
-const defaultConfig: Config = {
-  host: 'localhost',
+export const defaultConfig: Config = {
+  hostname: window.location.hostname,
   port: '8448',
   endpoint: '/api/v1/ws',
   serverUrl: 'ws://localhost:8448/api/v1/ws',
-}
+} as const
 
 export const configAtom = atomWithStorage<Config>('pr-web-config', defaultConfig)
 

--- a/src/config/use-config.tsx
+++ b/src/config/use-config.tsx
@@ -8,7 +8,7 @@ export const defaultConfig: Config = {
   hostname: window.location.hostname,
   port: '8448',
   endpoint: '/api/v1/ws',
-  serverUrl: 'ws://localhost:8448/api/v1/ws',
+  serverUrl: `ws://${window.location.hostname}:8448/api/v1/ws`,
 } as const
 
 export const configAtom = atomWithStorage<Config>('pr-web-config', defaultConfig)

--- a/src/pages/config.tsx
+++ b/src/pages/config.tsx
@@ -1,6 +1,7 @@
+import { Button } from 'components/button'
 import Head from 'components/head'
 import { TopNav } from 'components/top-nav'
-import { useConfig } from 'config/use-config'
+import { defaultConfig, useConfig } from 'config/use-config'
 import { dict } from 'constant'
 import type { FC } from 'react'
 
@@ -10,16 +11,30 @@ export const Config: FC = () => {
     updateConfig({ [type]: e.currentTarget.value })
   }
 
+  const handleConfigDetect = () => {
+    updateConfig({
+      hostname: window.location.hostname,
+      port: window.location.port,
+      endpoint: '/api/v1/ws',
+    })
+  }
+
+  const handleConfigReset = () => {
+    updateConfig(defaultConfig)
+  }
+
   return (
     <div>
       <Head title={dict.headerConfig} />
       <TopNav />
       <div>
         <div>Config</div>
-        <input value={config.host} onChange={handleChange('host')} />
+        <input value={config.hostname} onChange={handleChange('host')} />
         <input value={config.port} onChange={handleChange('port')} />
         <input value={config.endpoint} onChange={handleChange('endpoint')} />
         <div>{config.serverUrl}</div>
+        <Button onClick={handleConfigDetect}>Auto detect</Button>
+        <Button onClick={handleConfigReset}>Reset to default</Button>
       </div>
     </div>
   )

--- a/src/pages/config.tsx
+++ b/src/pages/config.tsx
@@ -29,7 +29,7 @@ export const Config: FC = () => {
       <TopNav />
       <div>
         <div>Config</div>
-        <input value={config.hostname} onChange={handleChange('host')} />
+        <input value={config.hostname} onChange={handleChange('hostname')} />
         <input value={config.port} onChange={handleChange('port')} />
         <input value={config.endpoint} onChange={handleChange('endpoint')} />
         <div>{config.serverUrl}</div>


### PR DESCRIPTION
# Update config schema and UI

## Primary changes
- Add auto-detect and reset buttons to config UI
- Use window.location for default hostname


## Secondary changes
- Change 'host' to 'hostname' for clarity
- Make port a string to allow empty values
- Add validation for port range (1-65535)
- Update tests for new schema

