### PR TITLE
Implement sliders for all sinks

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -6,7 +6,7 @@
     "es2021": true
   },
   "parser": "@typescript-eslint/parser",
-  "plugins": [],
+  "plugins": ["eslint-comments"],
   "extends": [
     "eslint:all",
     "plugin:@typescript-eslint/all",
@@ -50,6 +50,7 @@
     "arrow-body-style": "off",
     "no-param-reassign": "off",
     "no-void": "off",
+    "eslint-comments/no-unused-disable": "warn",
     "@typescript-eslint/consistent-type-definitions": "off",
     "@typescript-eslint/explicit-function-return-type": "off",
     "@typescript-eslint/explicit-module-boundary-types": "off",
@@ -68,6 +69,14 @@
     "@typescript-eslint/return-await": "off",
     "@typescript-eslint/sort-type-constituents": "off",
     "@typescript-eslint/strict-boolean-expressions": "off",
+    "@typescript-eslint/prefer-ts-expect-error": "error",
+    "@typescript-eslint/ban-ts-comment": [
+      "error",
+      {
+        "ts-ignore": "allow-with-description",
+        "ts-expect-error": "allow-with-description"
+      }
+    ],
     "@typescript-eslint/no-confusing-void-expression": [
       "error",
       {

--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -48,6 +48,7 @@
       }
     ],
     "arrow-body-style": "off",
+    "no-param-reassign": "off",
     "no-void": "off",
     "@typescript-eslint/consistent-type-definitions": "off",
     "@typescript-eslint/explicit-function-return-type": "off",

--- a/package.json
+++ b/package.json
@@ -69,6 +69,7 @@
     "eslint-config-airbnb-typescript": "18.0.0",
     "eslint-config-prettier": "9.1.0",
     "eslint-plugin-cypress": "2.15.1",
+    "eslint-plugin-eslint-comments": "^3.2.0",
     "eslint-plugin-import": "2.29.1",
     "eslint-plugin-jsx-a11y": "6.8.0",
     "eslint-plugin-react": "7.34.1",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -143,6 +143,9 @@ importers:
       eslint-plugin-cypress:
         specifier: 2.15.1
         version: 2.15.1(eslint@8.57.0)
+      eslint-plugin-eslint-comments:
+        specifier: ^3.2.0
+        version: 3.2.0(eslint@8.57.0)
       eslint-plugin-import:
         specifier: 2.29.1
         version: 2.29.1(@typescript-eslint/parser@7.6.0(eslint@8.57.0)(typescript@5.4.5))(eslint@8.57.0)
@@ -3148,6 +3151,13 @@ packages:
       { integrity: sha512-eLHLWP5Q+I4j2AWepYq0PgFEei9/s5LvjuSqWrxurkg1YZ8ltxdvMNmdSf0drnsNo57CTgYY/NIHHLRSWejR7w== }
     peerDependencies:
       eslint: '>= 3.2.1'
+
+  eslint-plugin-eslint-comments@3.2.0:
+    resolution:
+      { integrity: sha512-0jkOl0hfojIHHmEHgmNdqv4fmh7300NdpA9FFpF7zaoLvB/QeXOGNLIo86oAveJFrfB1p05kC8hpEMHM8DwWVQ== }
+    engines: { node: '>=6.5.0' }
+    peerDependencies:
+      eslint: '>=4.19.1'
 
   eslint-plugin-import@2.29.1:
     resolution:
@@ -9421,6 +9431,12 @@ snapshots:
     dependencies:
       eslint: 8.57.0
       globals: 13.20.0
+
+  eslint-plugin-eslint-comments@3.2.0(eslint@8.57.0):
+    dependencies:
+      escape-string-regexp: 1.0.5
+      eslint: 8.57.0
+      ignore: 5.3.1
 
   eslint-plugin-import@2.29.1(@typescript-eslint/parser@7.6.0(eslint@8.57.0)(typescript@5.4.5))(eslint@8.57.0):
     dependencies:

--- a/src/api/types.ts
+++ b/src/api/types.ts
@@ -1,0 +1,14 @@
+// @TODO (undg) 2024-09-19: generate those types on the BE or generate them from GetSchema API provided by the server.
+
+export type WsMessage = {
+  action: 'GetSinks' | 'SetSinks' // and more
+  status: number // 400x
+  value?: GetSinks[] // and more
+  error?: string
+}
+export type GetSinks = {
+  name: string
+  label: string
+  volume: number
+  muted: boolean
+}

--- a/src/api/types.ts
+++ b/src/api/types.ts
@@ -1,14 +1,28 @@
 // @TODO (undg) 2024-09-19: generate those types on the BE or generate them from GetSchema API provided by the server.
 
-export type WsMessage = {
-  action: 'GetSinks' | 'SetSinks' // and more
-  status: number // 400x
-  value?: GetSinks[] // and more
-  error?: string
-}
+type Action = 'GetSinks' | 'SetSinks' // and more
+
 export type GetSinks = {
+  /** uniq name, can be used as ID */
   name: string
   label: string
-  volume: number
+  /** volume is a number string */
+  volume: string
   muted: boolean
+}
+export type GetWsMessage = {
+  action: Action
+  status: number // 400x
+  payload?: GetSinks[] // and more
+  error?: string
+}
+
+type SendSink = {
+  name: string
+  volume: string
+}
+
+export type SendWsMessate = {
+  action: Action
+  payload: SendSink
 }

--- a/src/constant.ts
+++ b/src/constant.ts
@@ -1,9 +1,9 @@
 export const MIN_VOLUME = 0
 /**
- * Max volume 1.5 is 150%. Although you can set it as loud as you like,
- * value above 2.0 (200%) can damage your speakers.
+ * Max volume 150 is 150%. Although you can set it as loud as you like,
+ * value above 200 (200%) can damage your speakers.
  */
-export const MAX_VOLUME = 1.5
+export const MAX_VOLUME = 150
 
 export const APP_NAME = 'Pulse Remote'
 

--- a/src/pages/controller.tsx
+++ b/src/pages/controller.tsx
@@ -70,7 +70,11 @@ export const ControllerOutput: React.FC = () => {
     <Layout header={dict.headerOutput}>
       <section className='flex flex-col gap-8'>
         {sinks.map(sink => (
-          <div key={sink.name} className='grid-col-2 grid' style={{ gridTemplateColumns: 'minmax(auto, 300px) auto' }}>
+          <div
+            key={sink.name}
+            className='grid-col-2 grid gap-4'
+            style={{ gridTemplateColumns: 'minmax(auto, 30vw) auto' }}
+          >
             <Small>{sink.label}</Small>
             <Slider
               className='mb-8'

--- a/src/pages/controller.tsx
+++ b/src/pages/controller.tsx
@@ -1,9 +1,12 @@
+import type { GetSinks, GetWsMessage } from 'api/types'
 import { useWebSocketApi } from 'api/use-web-socket-api'
 import { Layout } from 'components/layout'
 import { Slider } from 'components/slider'
+import { Small } from 'components/typography'
 import { MAX_VOLUME, MIN_VOLUME, dict } from 'constant'
-import { atom, useAtom } from 'jotai'
+import { atom } from 'jotai'
 import { useAtomDevtools } from 'jotai-devtools'
+import { useImmerAtom } from 'jotai-immer'
 import { useCallback, useEffect } from 'react'
 import { useDebounce } from 'utils/use-debounce'
 
@@ -12,27 +15,36 @@ if (process.env.NODE_ENV !== 'production') {
   volumeAtom.debugLabel = 'volumeAtom'
 }
 
+export const sinksAtom = atom<GetSinks[]>([])
+if (process.env.NODE_ENV !== 'production') {
+  sinksAtom.debugLabel = 'sinksAtom'
+}
+
 export const ControllerOutput: React.FC = () => {
-  const [volume, setVolume] = useAtom(volumeAtom)
-  useAtomDevtools(volumeAtom)
+  const [sinks, updateSinks] = useImmerAtom(sinksAtom)
+  useAtomDevtools(sinksAtom)
+
   const { sendMessage, lastMessage } = useWebSocketApi()
 
-  const debouncedVolume = useDebounce(volume, 100)
+  const debouncedSinks = useDebounce(sinks, 100)
 
   useEffect(() => {
-    if (debouncedVolume !== null) {
-      sendMessage(JSON.stringify({ action: 'SetVolume', value: debouncedVolume }))
+    for (const sink of debouncedSinks) {
+      sendMessage(JSON.stringify({ action: 'SetSink', payload: { name: sink.name, volume: sink.volume } }))
     }
-  }, [debouncedVolume, sendMessage])
+  }, [debouncedSinks, sendMessage])
 
   useEffect(() => {
     if (lastMessage && typeof lastMessage.data === 'string') {
-      const parsedMessage = JSON.parse(lastMessage.data) as { action: string; value?: string }
-      if (parsedMessage.action === 'GetVolume' && parsedMessage.value !== undefined) {
-        setVolume(Number(parsedMessage.value))
-      }
+      const parsedMessage = JSON.parse(lastMessage.data) as GetWsMessage
+      updateSinks(draft => {
+        if (parsedMessage.action === 'GetSinks' && Array.isArray(parsedMessage.payload)) {
+          return parsedMessage.payload
+        }
+        return draft
+      })
     }
-  }, [lastMessage, setVolume])
+  }, [lastMessage, updateSinks])
 
   const handleRefresh = useCallback(() => {
     sendMessage(JSON.stringify({ action: 'GetVolume' }))
@@ -43,23 +55,35 @@ export const ControllerOutput: React.FC = () => {
   }, [handleRefresh])
 
   const handleVolumeChange = useCallback(
-    (newValue: number[]) => {
-      setVolume(newValue[0])
+    (name: string) => (newValue: number[]) => {
+      updateSinks(draft => {
+        const sink = draft.find(s => s.name === name)
+        if (sink) {
+          sink.volume = newValue[0].toString()
+        }
+      })
     },
-    [setVolume],
+    [updateSinks],
   )
 
   return (
     <Layout header={dict.headerOutput}>
-      <section className='mb-8'>
-        <Slider
-          title='Volume'
-          min={MIN_VOLUME}
-          max={MAX_VOLUME}
-          value={[volume ?? 0]}
-          step={0.01}
-          onValueChange={handleVolumeChange}
-        />
+      <section className='flex flex-col gap-8'>
+        {sinks.map(sink => (
+          <div key={sink.name} className='grid-col-2 grid' style={{ gridTemplateColumns: 'minmax(auto, 300px) auto' }}>
+            <Small>{sink.label}</Small>
+            <Slider
+              className='mb-8'
+              name={sink.label}
+              title='Volume'
+              min={MIN_VOLUME}
+              max={MAX_VOLUME}
+              value={[Number(sink.volume)]}
+              step={1}
+              onValueChange={handleVolumeChange(sink.name)}
+            />
+          </div>
+        ))}
       </section>
     </Layout>
   )

--- a/src/setup-tests.ts
+++ b/src/setup-tests.ts
@@ -27,7 +27,6 @@ beforeAll(() => {
         removeEventListener: (_: 'change', listener: () => void): void => {
           const index = listeners.indexOf(listener)
           if (index >= 0) {
-            // eslint-disable-next-line @typescript-eslint/no-magic-numbers
             listeners.splice(index, 1)
           }
         },


### PR DESCRIPTION
## Primary

After upgrading go-prapi to v0.0.25, I can get all sinks (audio cards) and update them separately. Updated controller component with this functionality.

## Secondary
- **relax eslint to work with immer**
- **stiffer eslint**
- **Add types for BE interfaces**

## Before
![Screenshot_20240919-022647.png](https://github.com/user-attachments/assets/94e22d83-9311-476d-8f30-861906f124f3)


## After
![Screenshot_20240919-022901.png](https://github.com/user-attachments/assets/5f9595df-e610-43d2-8360-65ea40ae67cc)

