### PR TITLE
Bump BE version in readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@
 
 ## Pulse Remote Frontend
 
-React frontend for [go-prapi](https://github.com/undg/go-prapi) (v0.2.1) websocket server.
+React frontend for [go-prapi](https://github.com/undg/go-prapi) (v0.3.0) websocket server.
 
 Control Linux PC sound remotely from your phone.
 


### PR DESCRIPTION
Update README. FE is compatible with v0.3.0 or go-prapi
