### PR TITLE
Make style more compact

### DIFF
--- a/src/components/top-nav.tsx
+++ b/src/components/top-nav.tsx
@@ -14,31 +14,31 @@ export const TopNav: FC = () => {
 
 	return (
 		<nav className='mb-8 flex flex-wrap-reverse justify-between gap-4'>
-			<div className='flex justify-between gap-4'>
+			<div className='flex justify-between gap-2'>
 				<Link to='/' data-testid={testid.gotoOutputDevices}>
-					<Button variant='outline'>
+					<Button variant='outline' size='sm'>
 						<Volume2 />
 					</Button>
 				</Link>
 				<Link to='/input' data-testid={testid.gotoInputDevices}>
-					<Button variant='outline'>
+					<Button variant='outline' size='sm'>
 						<Mic />
 					</Button>
 				</Link>
 			</div>
 
-			<div className='flex justify-between gap-4'>
+			<div className='flex justify-between gap-2'>
 				<Link to='/about' data-testid={testid.gotoAbout}>
-					<Button variant='outline'>
+					<Button variant='outline' size='sm'>
 						<Info />
 					</Button>
 				</Link>
 				<Link to='/config' data-testid={testid.gotoConfig}>
-					<Button variant='outline'>
+					<Button variant='outline' size='sm'>
 						<Settings />
 					</Button>
 				</Link>
-				<Button variant='outline' data-testid={testid.btnTheme} onClick={handleThemeToggle}>
+				<Button variant='outline' size='sm' data-testid={testid.btnTheme} onClick={handleThemeToggle}>
 					{theme === 'light' && <Sun />}
 					{theme === 'dark' && <Moon />}
 				</Button>

--- a/src/components/volume-slider.tsx
+++ b/src/components/volume-slider.tsx
@@ -77,22 +77,23 @@ export const VolumeSlider: React.FC<{
 				{props.muted ? <VolumeOff color='red' /> : <Volume />}
 			</Toggle>
 			<Small className='self-end truncate text-right text-xs'>{props.label}</Small>
-			<div
-				className={cn(
-					//
-					'text-green-500',
-					props.volume >= 75 && 'text-orange-500',
-					props.volume >= 100 && 'text-red-500',
-				)}
-			>
-				{props.volume}%
-			</div>
-			<div className='flex'>
+			<div className='col-span-2 flex'>
 				<Button data-testid={testid.btnVolumeDown} variant={`ghost`} onClick={handleVolumeDown}>
 					<MinusCircleIcon />
 				</Button>
 				<Slider
 					className='top-2 col-span-1 mb-4'
+					thumbContent={
+						<span
+							className={cn(
+								'text-xs text-green-500',
+								props.volume >= 75 && 'text-orange-500',
+								props.volume >= 100 && 'text-red-500',
+							)}
+						>
+							{props.volume}%
+						</span>
+					}
 					name={props.label}
 					title={props.label}
 					min={config.minVolume}

--- a/src/components/volume-slider.tsx
+++ b/src/components/volume-slider.tsx
@@ -78,7 +78,7 @@ export const VolumeSlider: React.FC<{
 			</Toggle>
 			<Small className='self-end truncate text-right text-xs'>{props.label}</Small>
 			<div className='col-span-2 flex'>
-				<Button data-testid={testid.btnVolumeDown} variant={`ghost`} onClick={handleVolumeDown}>
+				<Button data-testid={testid.btnVolumeDown} variant={`ghost`} size='icon' onClick={handleVolumeDown}>
 					<MinusCircleIcon />
 				</Button>
 				<Slider
@@ -103,7 +103,7 @@ export const VolumeSlider: React.FC<{
 					onValueChange={props.onValueChange}
 					onValueCommit={props.onValueCommit}
 				/>
-				<Button data-testid={testid.btnVolumeUp} variant={`ghost`} onClick={handleVolumeUp}>
+				<Button data-testid={testid.btnVolumeUp} variant={`ghost`} size='icon' onClick={handleVolumeUp}>
 					<PlusCircleIcon />
 				</Button>
 			</div>

--- a/src/components/volume-slider.tsx
+++ b/src/components/volume-slider.tsx
@@ -1,4 +1,4 @@
-import { MinusCircleIcon, PlusCircleIcon, Volume, VolumeOff } from 'lucide-react'
+import { MinusCircleIcon, PlusCircleIcon, Volume1Icon, Volume2Icon, VolumeOff } from 'lucide-react'
 import { testid } from '../constant'
 import { Button } from '../primitives/button'
 import { Slider } from '../primitives/slider'
@@ -68,13 +68,15 @@ export const VolumeSlider: React.FC<{
 			style={{ gridTemplateColumns: '2em auto', gridTemplateRows: 'repeat(1em)' }}
 		>
 			<Toggle
-				variant='outline'
+				variant='default'
 				size='sm'
 				pressed={props.muted}
 				data-testid={testid.btnMuteToggle}
 				onClick={props.onMuteChange}
 			>
-				{props.muted ? <VolumeOff color='red' /> : <Volume />}
+				{(props.muted || props.volume === 0) && <VolumeOff color='red' />}
+				{(!(props.muted || props.volume === 0) && props.volume <= 75) && <Volume1Icon />}
+				{(!(props.muted || props.volume === 0) && props.volume > 75) && <Volume2Icon />}
 			</Toggle>
 			<Small className='self-end truncate text-right text-xs'>{props.label}</Small>
 			<div className='col-span-2 flex'>

--- a/src/components/volume-slider.tsx
+++ b/src/components/volume-slider.tsx
@@ -1,11 +1,18 @@
-import { MinusCircleIcon, PlusCircleIcon, Volume1Icon, Volume2Icon, VolumeOff } from 'lucide-react'
+import { MinusCircleIcon, PlusCircleIcon, Volume, Volume1, Volume2, VolumeOff } from 'lucide-react'
+import { useConfig } from '../config/use-config'
 import { testid } from '../constant'
 import { Button } from '../primitives/button'
 import { Slider } from '../primitives/slider'
 import { Toggle } from '../primitives/toggle'
 import { Small } from '../primitives/typography'
 import { cn } from '../utils/cn'
-import { useConfig } from '../config/use-config'
+
+const getVolumeIcon = (volume: number, muted: boolean) => {
+	if (muted || volume === 0) return <VolumeOff color='red' />
+	if (volume <= 50) return <Volume />
+	if (volume <= 90) return <Volume1 />
+	return <Volume2 />
+}
 
 export const VolumeSlider: React.FC<{
 	children?: React.ReactNode
@@ -74,9 +81,7 @@ export const VolumeSlider: React.FC<{
 				data-testid={testid.btnMuteToggle}
 				onClick={props.onMuteChange}
 			>
-				{(props.muted || props.volume === 0) && <VolumeOff color='red' />}
-				{(!(props.muted || props.volume === 0) && props.volume <= 75) && <Volume1Icon />}
-				{(!(props.muted || props.volume === 0) && props.volume > 75) && <Volume2Icon />}
+				{getVolumeIcon(props.volume, props.muted)}
 			</Toggle>
 			<Small className='self-end truncate text-right text-xs'>{props.label}</Small>
 			<div className='col-span-2 flex'>

--- a/src/pages/about.tsx
+++ b/src/pages/about.tsx
@@ -10,8 +10,6 @@ export default function About(): ReactElement {
 			<section>
 				<H2>Pulse Remote</H2>
 				<P>App for Linux. Control PC volume remotely. Works with PulseAudio and PipeWire.</P>
-
-				<H2>Source</H2>
 				<P>
 					<a href='https://github.com/undg/pulse-remote'>github.com/undg/pulse-remote</a>
 				</P>

--- a/src/primitives/slider.tsx
+++ b/src/primitives/slider.tsx
@@ -14,7 +14,7 @@ const Slider = React.forwardRef<
 		<SliderPrimitive.Track className='relative h-2 w-full grow overflow-hidden rounded-full bg-primary/20'>
 			<SliderPrimitive.Range className='absolute h-full bg-primary' />
 		</SliderPrimitive.Track>
-		<SliderPrimitive.Thumb className='flex size-10 items-center justify-center rounded-full border-2 border-primary bg-background ring-offset-background transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 disabled:pointer-events-none disabled:opacity-50'>
+		<SliderPrimitive.Thumb className='flex size-9 items-center justify-center rounded-full border-2 border-primary bg-background ring-offset-background transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 disabled:pointer-events-none disabled:opacity-50'>
 			{thumbContent}
 		</SliderPrimitive.Thumb>
 	</SliderPrimitive.Root>

--- a/src/primitives/slider.tsx
+++ b/src/primitives/slider.tsx
@@ -4,8 +4,8 @@ import { cn } from '../utils/cn'
 
 const Slider = React.forwardRef<
 	React.ElementRef<typeof SliderPrimitive.Root>,
-	React.ComponentPropsWithoutRef<typeof SliderPrimitive.Root> & { className?: string }
->(({ className, ...props }, ref) => (
+	React.ComponentPropsWithoutRef<typeof SliderPrimitive.Root> & { className?: string; thumbContent?: React.ReactNode }
+>(({ className, thumbContent, ...props }, ref) => (
 	<SliderPrimitive.Root
 		ref={ref}
 		className={cn('relative flex w-full touch-none select-none items-center', className)}
@@ -14,7 +14,9 @@ const Slider = React.forwardRef<
 		<SliderPrimitive.Track className='relative h-2 w-full grow overflow-hidden rounded-full bg-primary/20'>
 			<SliderPrimitive.Range className='absolute h-full bg-primary' />
 		</SliderPrimitive.Track>
-		<SliderPrimitive.Thumb className='block h-5 w-5 rounded-full border-2 border-primary bg-background ring-offset-background transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 disabled:pointer-events-none disabled:opacity-50' />
+		<SliderPrimitive.Thumb className='flex size-10 items-center justify-center rounded-full border-2 border-primary bg-background ring-offset-background transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 disabled:pointer-events-none disabled:opacity-50'>
+			{thumbContent}
+		</SliderPrimitive.Thumb>
 	</SliderPrimitive.Root>
 ))
 Slider.displayName = SliderPrimitive.Root.displayName

--- a/src/primitives/typography.tsx
+++ b/src/primitives/typography.tsx
@@ -3,7 +3,7 @@ import { cn } from '../utils/cn'
 
 export const H1: FC<PropsWithChildren<{ className?: string }>> = props => {
 	return (
-		<h1 className={cn('scroll-m-20 pb-8 text-3xl font-extrabold tracking-tight lg:text-5xl', props.className)}>
+		<h1 className={cn('scroll-m-20 pb-8 text-2xl font-extrabold tracking-tight lg:text-5xl', props.className)}>
 			{props.children}
 		</h1>
 	)
@@ -12,7 +12,7 @@ export const H1: FC<PropsWithChildren<{ className?: string }>> = props => {
 export const H2: FC<PropsWithChildren<{ className?: string }>> = props => {
 	return (
 		<h2
-			className={cn('first:mt- mt-6 scroll-m-20 border-b pb-2 text-2xl font-semibold tracking-tight', props.className)}
+			className={cn('first:mt- text-1xl mt-6 scroll-m-20 border-b pb-2 font-semibold tracking-tight', props.className)}
 		>
 			{props.children}
 		</h2>
@@ -21,13 +21,13 @@ export const H2: FC<PropsWithChildren<{ className?: string }>> = props => {
 
 export const H3: FC<PropsWithChildren<{ className?: string }>> = props => {
 	return (
-		<h3 className={cn('text-1xl mt-6 scroll-m-20 font-semibold tracking-tight', props.className)}>{props.children}</h3>
+		<h3 className={cn('mt-6 scroll-m-20 text-xl font-semibold tracking-tight', props.className)}>{props.children}</h3>
 	)
 }
 
 export const H4: FC<PropsWithChildren<{ className?: string }>> = props => {
 	return (
-		<h4 className={cn('mt-6 scroll-m-20 text-xl font-semibold tracking-tight', props.className)}>{props.children}</h4>
+		<h4 className={cn('mt-6 scroll-m-20 text-lg font-semibold tracking-tight', props.className)}>{props.children}</h4>
 	)
 }
 


### PR DESCRIPTION
- **move volume value to the thumb dot**
- **make more space for slider by compacting icon buttons**
- **different speaker icons for volume steps**
- **improve top nav for smaller devices**
- **smaller headers on small devices**
- **small rearrange about page**

<div style="display: flex; justify-content: center; gap: 20px; flex-wrap: wrap;">
  <img src="https://github.com/user-attachments/assets/464f7ee0-b1b8-4dbf-86d2-6310b97b3678" width="300" alt="Image1">
  <img src="https://github.com/user-attachments/assets/3e9cd49a-666e-43d6-a0a5-1a1830f74cfd" width="300" alt="Image2">
</div>
